### PR TITLE
Define a DaemonClient to talk to X-Ray over UDP

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ serde_json = "1.0"
 tracing-core = "0.1"
 tracing-serde = "0.1"
 tracing-subscriber = { version = "0.3.11", features = ["fmt", "json", "std"] }
+tokio = { version = "1.17.0", features = ["net", "rt", "macros"] }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# tracing-xray
+
+Type definitions: https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html
+Sending: https://docs.aws.amazon.com/xray/latest/devguide/xray-api-sendingdata.html
+
+## UDP
+To listen on the same port as the X-Ray daemon would, you can use `netcat`
+``` sh
+sudo yum install nc
+# Listen on port 2000
+nc -ul 2000
+```

--- a/src/xray_daemon.rs
+++ b/src/xray_daemon.rs
@@ -1,0 +1,64 @@
+use std::io;
+use tokio::net::UdpSocket;
+
+const DAEMON_HEADER: &[u8] = b"{\"format\": \"json\", \"version\": 1}\n";
+const DEFAULT_UDP_REMOTE_PORT: u16 = 2000;
+
+pub(crate) struct DaemonClient<S: ClientState> {
+    state: S,
+}
+
+struct Start {
+    remote_port: u16,
+}
+struct Connected {
+    sock: UdpSocket,
+}
+
+pub(crate) trait ClientState {}
+impl ClientState for Start {}
+impl ClientState for Connected {}
+
+impl DaemonClient<Start> {
+    pub(crate) fn new(remote_port: u16) -> Self {
+        DaemonClient {
+            state: Start { remote_port },
+        }
+    }
+
+    pub(crate) async fn connect(&self) -> io::Result<DaemonClient<Connected>> {
+        // Let the OS choose an IP and port for us...
+        let sock = UdpSocket::bind("0.0.0.0:0").await?;
+        let remote_addr = format!("127.0.0.1:{}", self.state.remote_port);
+        sock.connect(remote_addr).await?;
+        Ok(DaemonClient {
+            state: Connected { sock },
+        })
+    }
+}
+
+impl Default for DaemonClient<Start> {
+    fn default() -> Self {
+        DaemonClient::new(DEFAULT_UDP_REMOTE_PORT)
+    }
+}
+
+impl DaemonClient<Connected> {
+    pub(crate) async fn send(&self, buf: &[u8]) -> io::Result<usize> {
+        self.state.sock.send(&[DAEMON_HEADER, buf].concat()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn send_data() {
+        let buf = b"{\"hello\": \"world\"}";
+        let client: DaemonClient<Start> = Default::default();
+        let client = client.connect().await.unwrap();
+        let len = client.send(buf).await.unwrap();
+        assert_eq!(len, DAEMON_HEADER.len() + buf.len());
+    }
+}


### PR DESCRIPTION
This patch adds a `DaemonClient` type that uses the typestate pattern
to track the connection status of the `UdpSocket`. Once connected, we
are able to make use of the `send(...)` method. This includes the
daemon header automatically.

See "Sending segment documents to the X-Ray daemon":
https://docs.aws.amazon.com/xray/latest/devguide/xray-api-sendingdata.html