### PR TITLE
Fix Id/ParentId formats, add newline after each JSON trace

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,7 @@ where
                 //
                 // What we do:
                 // Convert `Id` to a `u64`, then format it as hex.
-                format!("{:08x}", id.into_u64())
+                format!("{:016x}", id.into_u64())
             },
             start_time: {
                 // What the docs say:
@@ -205,7 +205,7 @@ where
                         .unwrap_or("TODO".to_string())
                 }
             },
-            parent_id: { parent.map(|p| format!("{:08x}", p.id().into_u64())) },
+            parent_id: { parent.map(|p| format!("{:016x}", p.id().into_u64())) },
             kind: match attr.fields().field("AWS_XRAY_TRACE_ID").is_some() {
                 true => model::Kind::Segment,
                 false => model::Kind::Subsegment,

--- a/src/xray_daemon.rs
+++ b/src/xray_daemon.rs
@@ -46,7 +46,11 @@ impl Default for DaemonClient<Start> {
 
 impl DaemonClient<Connected> {
     pub(crate) async fn send(&self, buf: &[u8]) -> io::Result<usize> {
-        self.state.sock.send(&[DAEMON_HEADER, buf].concat()).await
+        let newline = b"\n";
+        self.state
+            .sock
+            .send(&[DAEMON_HEADER, buf, newline].concat())
+            .await
     }
 }
 


### PR DESCRIPTION
This fixes a few small bugs that were preventing the traces from being
accepted as valid by the Xray daemon.